### PR TITLE
Dependency fixes

### DIFF
--- a/META.json
+++ b/META.json
@@ -30,7 +30,6 @@
          "requires" : {
             "CPAN::Meta" : "0",
             "CPAN::Meta::Prereqs" : "0",
-            "Module::Build" : "0",
             "Module::Build::Tiny" : "0.035"
          }
       },

--- a/META.json
+++ b/META.json
@@ -49,6 +49,7 @@
       "runtime" : {
          "requires" : {
             "Encode" : "0",
+            "Exporter" : "5.57",
             "Types::Serialiser" : "0",
             "parent" : "0",
             "perl" : "5.008005"

--- a/cpanfile
+++ b/cpanfile
@@ -7,7 +7,6 @@ requires 'perl', '5.008005';
 on configure => sub {
     requires 'CPAN::Meta';
     requires 'CPAN::Meta::Prereqs';
-    requires 'Module::Build';
 };
 
 on test => sub {

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,7 @@
 requires 'Encode';
 requires 'Types::Serialiser';
 requires 'parent';
+requires 'Exporter', '5.57';
 requires 'perl', '5.008005';
 
 on configure => sub {

--- a/lib/TOML/Parser.pm
+++ b/lib/TOML/Parser.pm
@@ -2,7 +2,6 @@ package TOML::Parser;
 use 5.008005;
 use strict;
 use warnings;
-use utf8;
 use Encode;
 
 our $VERSION = "0.04";

--- a/lib/TOML/Parser/Tokenizer.pm
+++ b/lib/TOML/Parser/Tokenizer.pm
@@ -2,7 +2,6 @@ package TOML::Parser::Tokenizer;
 use 5.008005;
 use strict;
 use warnings;
-use utf8;
 
 use parent qw/Exporter/;
 

--- a/lib/TOML/Parser/Tokenizer.pm
+++ b/lib/TOML/Parser/Tokenizer.pm
@@ -3,7 +3,7 @@ use 5.008005;
 use strict;
 use warnings;
 
-use parent qw/Exporter/;
+use Exporter 5.57 'import';
 
 use constant DEBUG => $ENV{TOML_PARSER_TOKENIZER_DEBUG} ? 1 : 0;
 

--- a/lib/TOML/Parser/Tokenizer/Strict.pm
+++ b/lib/TOML/Parser/Tokenizer/Strict.pm
@@ -2,7 +2,6 @@ package TOML::Parser::Tokenizer::Strict;
 use 5.008005;
 use strict;
 use warnings;
-use utf8;
 
 use parent qw/TOML::Parser::Tokenizer/;
 BEGIN { import TOML::Parser::Tokenizer qw/:constant/ }

--- a/lib/TOML/Parser/Util.pm
+++ b/lib/TOML/Parser/Util.pm
@@ -2,7 +2,6 @@ package TOML::Parser::Util;
 use 5.008005;
 use strict;
 use warnings;
-use utf8;
 
 use parent qw/Exporter/;
 our @EXPORT_OK = qw/unescape_str/;

--- a/lib/TOML/Parser/Util.pm
+++ b/lib/TOML/Parser/Util.pm
@@ -3,7 +3,7 @@ use 5.008005;
 use strict;
 use warnings;
 
-use parent qw/Exporter/;
+use Exporter 5.57 'import';
 our @EXPORT_OK = qw/unescape_str/;
 
 sub unescape_str {


### PR DESCRIPTION
Various dependencies fixes:

- remove useless `use utf8;` when the source is just ASCII
- `use Exporter 5.57 'import';` instead of `use parent 'Exporter';`
- remove obsolete dependency on Module::Build as we use Module::Build::Tiny since 0.04.