### PR TITLE
Fix string zero "0" to be interpreted as "0"

### DIFF
--- a/lib/TOML/Parser/Tokenizer.pm
+++ b/lib/TOML/Parser/Tokenizer.pm
@@ -172,7 +172,7 @@ sub _tokenize_value {
     elsif (/\G$grammar_regexp->{value}->{string}/mgc) {
         warn "[TOKEN] STRING: $1" if DEBUG;
         $class->_skip_whitespace();
-        return [TOKEN_STRING, $1 || $2 || ''];
+        return [TOKEN_STRING, $1 // $2 // ''];
     }
     elsif (/\G$grammar_regexp->{value}->{inline}->{start}/mgc) {
         warn "[TOKEN] INLINE TABLE" if DEBUG;

--- a/lib/TOML/Parser/Tokenizer.pm
+++ b/lib/TOML/Parser/Tokenizer.pm
@@ -172,7 +172,7 @@ sub _tokenize_value {
     elsif (/\G$grammar_regexp->{value}->{string}/mgc) {
         warn "[TOKEN] STRING: $1" if DEBUG;
         $class->_skip_whitespace();
-        return [TOKEN_STRING, $1 // $2 // ''];
+        return [TOKEN_STRING, defined $1 ? $1 : defined $2 ? $2 : ''];
     }
     elsif (/\G$grammar_regexp->{value}->{inline}->{start}/mgc) {
         warn "[TOKEN] INLINE TABLE" if DEBUG;

--- a/t/001_parser/string_zero.t
+++ b/t/001_parser/string_zero.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use utf8;
+
+use Test::More tests => 1;
+
+use TOML::Parser;
+
+my $toml = do { local $/; <DATA> };
+
+my $data = TOML::Parser->new->parse($toml);
+
+is_deeply $data, {
+    string_zero => '0',
+    string_one  => '1',
+    string_two  => '2',
+};
+
+__DATA__
+string_zero = "0"
+string_one  = "1"
+string_two  = "2"

--- a/t/001_parser/string_zero.t
+++ b/t/001_parser/string_zero.t
@@ -2,19 +2,29 @@ use strict;
 use warnings;
 use utf8;
 
-use Test::More tests => 1;
+use Test::More tests => 2;
 
 use TOML::Parser;
 
+sub inflate_datetime {
+    my $dt = shift;
+    $dt =~ s/Z$/+00:00/;
+    return $dt;
+}
+
 my $toml = do { local $/; <DATA> };
 
-my $data = TOML::Parser->new->parse($toml);
+for my $strict (0, 1) {
+    my $parser = TOML::Parser->new(inflate_datetime => \&inflate_datetime, strict_mode => $strict);
+    my $data = $parser->parse($toml);
 
-is_deeply $data, {
-    string_zero => '0',
-    string_one  => '1',
-    string_two  => '2',
-};
+    is_deeply $data,
+        {
+        string_zero => '0',
+        string_one  => '1',
+        string_two  => '2',
+        };
+}
 
 __DATA__
 string_zero="0"

--- a/t/001_parser/string_zero.t
+++ b/t/001_parser/string_zero.t
@@ -17,6 +17,6 @@ is_deeply $data, {
 };
 
 __DATA__
-string_zero = "0"
-string_one  = "1"
-string_two  = "2"
+string_zero="0"
+string_one="1"
+string_two="2"


### PR DESCRIPTION
To fix #8.

Pick up string `0` in regex match result using logical defined-or.